### PR TITLE
Disable script processing and generating lockfile for yarn

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec;
 
 module.exports = function (packages) {
   return new Promise(function (resolve, reject) {
-    exec(`yarn add ${packages.join(' ')}`, (err, stdout, stderr) => {
+    exec(`yarn add  --no-lockfile --ignore-scripts ${packages.join(' ')}`, (err, stdout, stderr) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
I think post processing scripts for installs could be a vulnerability, so I disabled it for the CodeSandbox bundler just to be sure. Should also increase performance a bit.