### PR TITLE
Install bundles by directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "compression": "^1.6.2",
     "express": "^4.15.2",
+    "express-cluster": "0.0.4",
     "json-loader": "^0.5.4",
     "string-hash": "^1.1.3",
     "webpack": "^2.3.3"

--- a/src/app.js
+++ b/src/app.js
@@ -6,11 +6,11 @@ var extract = require('./extract');
 var resolveEntries = require('./resolveEntries');
 var bundle = require('./bundle');
 var utils = require('./utils');
-
+var exec = require('child_process').exec;
 
 app.use(compression());
 
-var isAvailable = true
+var isAvailable = true;
 
 function verifyAvailability(req, res, next) {
   if (isAvailable) {
@@ -32,7 +32,7 @@ function extractPackages (req, res, next) {
 function extractAndBundle (req, res) {
   var packages = req.params.packages.split('+');
   var packagePath = `packages/${utils.getHash(packages)}`;
-  isAvailable = false
+  isAvailable = false;
   extract(packages, packagePath)
     .then(resolveEntries(packages, packagePath))
     .then(bundle(packagePath))
@@ -48,12 +48,22 @@ function extractAndBundle (req, res) {
         dll: files[1]
       });
       isAvailable = true;
+      exec(`rm -rf ${packagePath}`, function (err, stdout, stderr) {
+        if (err) {
+          console.log(err);
+        }
+      })
     })
     .catch(function (error) {
       isAvailable = true;
       res.status(500).send({
         error: error.message
       });
+      exec(`rm -rf ${packagePath}`, function (err, stdout, stderr) {
+        if (err) {
+          console.log(err);
+        }
+      })
     });
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -31,15 +31,15 @@ function extractPackages (req, res, next) {
 
 function extractAndBundle (req, res) {
   var packages = req.params.packages.split('+');
+  var packagePath = `packages/${utils.getHash(packages)}`;
   isAvailable = false
-
-  extract(packages)
-    .then(resolveEntries(packages))
-    .then(bundle)
+  extract(packages, packagePath)
+    .then(resolveEntries(packages, packagePath))
+    .then(bundle(packagePath))
     .then(function respond () {
       return Promise.all([
-        utils.readFile(path.resolve('manifest.json')),
-        utils.readFile(path.resolve('dll.js'))
+        utils.readFile(path.resolve(packagePath, 'manifest.json')),
+        utils.readFile(path.resolve(packagePath, 'dll.js'))
       ]);
     })
     .then(function (files) {

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -50,11 +50,14 @@ module.exports = function (packagePath) {
           .then(function (manifestJson) {
             var manifest = JSON.parse(manifestJson);
 
-            manifest.content = utils.cleanManifestContent(manifest, entries);
+            manifest.content = utils.cleanManifestContent(manifest, entries, packagePath);
             manifest.externals = utils.createExternals(manifest);
 
             return utils.writeFile(path.resolve(packagePath, 'manifest.json'), JSON.stringify(manifest, null, 2));
-          });
+          })
+          .catch((err) => {
+            console.log(err);
+          })
       });
   }
 }

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -3,56 +3,58 @@ var path = require('path');
 var utils = require('./utils');
 var getVendors = require('./getVendors');
 
-module.exports = function (entries) {
-  return getVendors(entries)
-    .then(function (vendors) {
-      var webpackConfig = {
-        context: '/',
-        entry: { vendors: vendors },
-        output: {
-          path: path.resolve(),
-          filename: 'dll.js',
-          library: 'dll_bundle'
-        },
-        plugins: [
-          new webpack.DllPlugin({
-           path: path.resolve('manifest.json'),
-           name: 'dll_bundle'
-         }),
-         new webpack.optimize.UglifyJsPlugin({minimize: true, mangle: false})
-       ],
-       resolve: {
-         modules: [path.resolve('packages', 'node_modules')]
-       },
-       module: {
-         loaders: [{
-           test: /\.json$/,
-           loader: 'json'
-         }]
-       }
-      };
-
-      var vendorsCompiler = webpack(webpackConfig);
-
-      return new Promise(function (resolve, reject) {
-        vendorsCompiler.run(function (err) {
-          if (err) {
-            return reject(err);
+module.exports = function (packagePath) {
+  return function (entries) {
+    return getVendors(entries, packagePath)
+      .then(function (vendors) {
+        var webpackConfig = {
+          context: '/',
+          entry: { vendors: vendors },
+          output: {
+            path: path.resolve(packagePath),
+            filename: 'dll.js',
+            library: 'dll_bundle'
+          },
+          plugins: [
+            new webpack.DllPlugin({
+              path: path.resolve(packagePath, 'manifest.json'),
+              name: 'dll_bundle'
+            }),
+            new webpack.optimize.UglifyJsPlugin({minimize: true, mangle: false})
+          ],
+          resolve: {
+            modules: [path.resolve(packagePath, 'node_modules')]
+          },
+          module: {
+            loaders: [{
+              test: /\.json$/,
+              loader: 'json'
+            }]
           }
+        };
 
-          resolve();
-        });
-      })
-        .then(function () {
-          return utils.readFile(path.resolve('manifest.json'));
+        var vendorsCompiler = webpack(webpackConfig);
+
+        return new Promise(function (resolve, reject) {
+          vendorsCompiler.run(function (err) {
+            if (err) {
+              return reject(err);
+            }
+
+            resolve();
+          });
         })
-        .then(function (manifestJson) {
-          var manifest = JSON.parse(manifestJson);
+          .then(function () {
+            return utils.readFile(path.resolve(packagePath, 'manifest.json'));
+          })
+          .then(function (manifestJson) {
+            var manifest = JSON.parse(manifestJson);
 
-          manifest.content = utils.cleanManifestContent(manifest, entries);
-          manifest.externals = utils.createExternals(manifest);
+            manifest.content = utils.cleanManifestContent(manifest, entries);
+            manifest.externals = utils.createExternals(manifest);
 
-          return utils.writeFile(path.resolve('manifest.json'), JSON.stringify(manifest, null, 2));
-        });
-    });
+            return utils.writeFile(path.resolve(packagePath, 'manifest.json'), JSON.stringify(manifest, null, 2));
+          });
+      });
+  }
 }

--- a/src/extract.js
+++ b/src/extract.js
@@ -1,8 +1,8 @@
 var exec = require('child_process').exec;
 
-module.exports = function (packages) {
+module.exports = function (packages, packagePath) {
   return new Promise(function (resolve, reject) {
-    exec(`cd packages && yarn add --no-lockfile --ignore-scripts ${packages.join(' ')}`, (err, stdout, stderr) => {
+    exec(`mkdir -p ${packagePath} && cd ${packagePath} && yarn add --no-lockfile --ignore-scripts ${packages.join(' ')}`, (err, stdout, stderr) => {
       if (err) {
         console.log(err);
         reject(err);

--- a/src/extract.js
+++ b/src/extract.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec;
 
 module.exports = function (packages, packagePath) {
   return new Promise(function (resolve, reject) {
-    exec(`mkdir -p ${packagePath} && cd ${packagePath} && yarn add --no-lockfile --ignore-scripts ${packages.join(' ')}`, (err, stdout, stderr) => {
+    exec(`mkdir -p ${packagePath} && cd ${packagePath} && yarn add --no-lockfile --ignore-scripts ${packages.join(' ')}`, function (err, stdout, stderr) {
       if (err) {
         console.log(err);
         reject(err);

--- a/src/getVendors.js
+++ b/src/getVendors.js
@@ -2,15 +2,15 @@ var utils = require('./utils');
 var path = require('path');
 var findEntryPoints = require('./findEntryPoints');
 
-module.exports = function (entries) {
+module.exports = function (entries, packagePath) {
   var entryKeys = Object.keys(entries);
 
   return Promise.all(entryKeys.map(function (entryKey) {
-    return findEntryPoints(entryKey, path.resolve('packages', 'node_modules', entryKey));
+    return findEntryPoints(entryKey, path.resolve(packagePath, 'node_modules', entryKey));
   }))
     .then(function (entryPointsList) {
       return entryPointsList.reduce(function (entryPoints, entryPointList, index) {
-        var directEntryPath = path.resolve('packages', 'node_modules', entryKeys[index], entries[entryKeys[index]]);
+        var directEntryPath = path.resolve(packagePath, 'node_modules', entryKeys[index], entries[entryKeys[index]]);
 
         if (entryPointList.indexOf(directEntryPath) === -1) {
           entryPointList.push(directEntryPath);

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,10 @@
-const cluster = require('cluster');
+const cluster = require('express-cluster');
 const os = require('os');
-const exec = require('child_process').exec;
 const app = require ('./app');
 
 const PORT = process.env.NODE_ENV === 'production' ? 80 : 5500;
-const numCPUs = os.cpus().length;
 
-if (cluster.isMaster) {
-  console.log(`Master ${process.pid} is running`);
-
-  // Fork workers
-  for (let i = 0; i < numCPUs; i++) {
-    cluster.fork();
-  }
-
-  cluster.on('exit', (worker, code, signal) => {
-    console.log(`Worker ${worker.process.pid} died`);
-    cluster.fork();
-  })
-} else {
-  const server = app.listen(PORT);
-
-  console.log(`Worker ${process.pid} started`);
-}
-
-// Delete packages every day, keep clean
-setInterval(function () {
-  exec('rm -rf packages && mkdir packages')
-}, 86400000)
+cluster(function (worker) {
+  console.log('Hello from worker worker ' + worker.id);
+  return app.listen(PORT)
+});

--- a/src/resolveEntries.js
+++ b/src/resolveEntries.js
@@ -1,12 +1,12 @@
 var path = require('path');
 var utils = require('./utils');
 
-module.exports = function resolveEntries (packages) {
+module.exports = function resolveEntries (packages, packagePath) {
   return function () {
     return Promise.all(packages.map(function (package) {
       var packageName = utils.getPackageName(package);
 
-      return utils.readFile(path.resolve('packages', 'node_modules', packageName, 'package.json'))
+      return utils.readFile(path.resolve(packagePath, 'node_modules', packageName, 'package.json'))
         .then((result) => JSON.parse(result));
     }))
       .then(function (results) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,19 @@ var hash = require('string-hash');
 var path = require('path');
 
 module.exports = {
+  getHash: function (packages) {
+    if (!packages || Object.keys(packages).length === 0) {
+      return null;
+    }
+    var packagesList = Object.keys(packages).map(function (key) {
+      return key + ':' + packages[key];
+    }).sort(function (a, b) {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    });
+    return String(hash(JSON.stringify(packagesList)));
+  },
   readFile: function (path) {
     return new Promise(function (resolve, reject) {
       fs.readFile(path, 'utf-8', function (error, content) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,7 @@ module.exports = {
       file.match(/.bundle.js$/)
     )
   },
-  cleanManifestContent: function (manifest, entries) {
+  cleanManifestContent: function (manifest, entries, packagePath) {
     var entryKeys = Object.keys(entries);
     var entryPaths = entryKeys.reduce(function (currentEntryPaths, entryKey) {
       return currentEntryPaths.concat(path.join(entryKey, entries[entryKey]));
@@ -84,7 +84,7 @@ module.exports = {
 
     return Object.keys(manifest.content).reduce(function (currentManifest, key) {
       var entryMatchIndex = entryPaths.reduce(function (matchIndex, entryPath, index) {
-        if (key === '.' + path.join(projectPath, 'packages', 'node_modules', entryPath)) {
+        if (key === '.' + path.join(projectPath, packagePath, 'node_modules', entryPath)) {
           return index;
         }
 
@@ -94,10 +94,10 @@ module.exports = {
       var pathKey = key.replace(projectPath, '');
 
       if (entryMatchIndex >= 0) {
-        pathKey = './' + path.join('packages', 'node_modules', entryKeys[entryMatchIndex]);
+        pathKey = './' + path.join(packagePath, 'node_modules', entryKeys[entryMatchIndex]);
       }
 
-      currentManifest[pathKey.replace('./packages', '.')] = manifest.content[key].id;
+      currentManifest[pathKey.replace(packagePath + '/', '')] = manifest.content[key].id;
 
       return currentManifest;
     }, {});


### PR DESCRIPTION
Now bundles get bundled in a separate directory (for example `packages/311127281`). This ensures clean installation between all installations.