### PR TITLE
Add node polyfills manually

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -1,8 +1,17 @@
 var exec = require('child_process').exec;
 
+/**
+ * We add these dependencies manually, because this is part of the webpack dependencies
+ * and not part of the packager dependencies. If any package tries to import `buffer`
+ * it will only load the direct entrypoints of `buffer`, not the entrypoints of its dependencies.
+ * 
+ * This will add all needed entrypoints for these packages.
+*/
+var POLYFILL_DEPENDENCIES = ['buffer', 'setimmediate'];
+
 module.exports = function (packages, packagePath) {
   return new Promise(function (resolve, reject) {
-    exec(`mkdir -p ${packagePath} && cd ${packagePath} && yarn add ${packages.join(' ')} --no-lockfile --ignore-scripts --non-interactive --no-bin-links --no-lockfile --ignore-engines`, function (err, stdout, stderr) {
+    exec(`mkdir -p ${packagePath} && cd ${packagePath} && yarn add ${packages.join(' ')} ${POLYFILL_DEPENDENCIES.join(' ')} --no-lockfile --ignore-scripts --non-interactive --no-bin-links --no-lockfile --ignore-engines`, function (err, stdout, stderr) {
       if (err) {
         reject(err.message.indexOf('versions') >= 0 ? new Error('INVALID_VERSION') : err);
       } else {


### PR DESCRIPTION
This will fix dependencies that use the `Buffer` or `setImmediate` feature. This is polyfilled by webpack by default, but the entry points of the subdependencies of these polyfills are never added. 

We can check if polyfills are actually used before adding these 2 dependencies, but I think this addition is so small that it's not worth the effort.