### PR TITLE
Attempt to fix css paths

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -80,5 +80,6 @@ createTests({
   'slate': '0.20.2',
   'react-icons': '2.2.5',
   'react-router-dom': '4.1.1',
-  'react-draggable': '2.2.6'
+  'react-draggable': '2.2.6',
+  'todomvc-app-css': '2.1.0'
 })

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -63,8 +63,5 @@ module.exports = function (packagePath) {
             return utils.writeFile(path.resolve(packagePath, 'manifest.json'), JSON.stringify(manifest, null, 2));
           })
       })
-      .catch(function (err) {
-        console.log(err);
-      })
   }
 }

--- a/src/manifests/todomvc-app-css_2.1.0.json
+++ b/src/manifests/todomvc-app-css_2.1.0.json
@@ -1,0 +1,10 @@
+{
+  "name": "dll_bundle",
+  "content": {
+    "./node_modules/todomvc-app-css/index.css": 0
+  },
+  "externals": {
+    "todomvc-app-css/index.css": "dll_bundle(0)",
+    "todomvc-app-css/index": "dll_bundle(0)"
+  }
+}

--- a/src/middleware/extractAndBundle.js
+++ b/src/middleware/extractAndBundle.js
@@ -45,7 +45,7 @@ function extractAndBundle (req, res) {
       currentTime = Date.now()
 
       verifyAvailability.isAvailable = true;
-      res.status(500).send(error.message);
+      res.status(500).send({ error: error.message });
 
       var stats = fs.lstatSync(packagePath);
       if (stats.isDirectory()) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,7 @@ module.exports = {
   cleanManifestContent: function (manifest, entries, packagePath) {
     var entryKeys = Object.keys(entries);
     var entryPaths = entryKeys.reduce(function (currentEntryPaths, entryKey) {
-      return currentEntryPaths.concat(path.join(entryKey, entries[entryKey].fallbackDir || entries[entryKey].main));
+      return currentEntryPaths.concat(path.join(entryKey, entries[entryKey].fallbackDir == null ? entries[entryKey].main : entries[entryKey].fallbackDir));
     }, []);
     var projectPath = path.resolve();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,13 +2312,9 @@ os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
-os-homedir@1.0.1:
+os-homedir@1.0.1, os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.1.tgz#0d62bdf44b916fd3bbdcf2cab191948fb094f007"
-
-os-homedir@^1.0.0, os-homedir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 os-locale@^1.4.0:
   version "1.4.0"
@@ -2625,7 +2621,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.79.0:
+request@2.79.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -2650,7 +2646,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
I'm not sure if this is only related to css, I happened to find this happening with `todomvc-app-css`. This dependency doesn't have a main entry in the package.json, which causes 

`return currentEntryPaths.concat(path.join(entryKey, entries[entryKey].fallbackDir || entries[entryKey].main);` to throw, because path tries to join with a null value.

This results in no externals in the final output.

I also removed the catch statement, so the bundle will not silently fail when something goes wrong with packaging. The response of the error is now in json `{"error": error}.